### PR TITLE
Revalidate field on demand

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -5354,10 +5354,10 @@ var _extends = _assign || function (target) { for (var i = 1; i < arguments.leng
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var BlockTree = __webpack_require__(79);
-var ContentState = __webpack_require__(42);
+var ContentState = __webpack_require__(43);
 var EditorBidiService = __webpack_require__(193);
 var Immutable = __webpack_require__(3);
-var SelectionState = __webpack_require__(23);
+var SelectionState = __webpack_require__(24);
 
 var OrderedSet = Immutable.OrderedSet,
     Record = Immutable.Record,
@@ -6013,12 +6013,12 @@ module.exports = shouldUseNative() ? Object.assign : function (target, source) {
 
 var CharacterMetadata = __webpack_require__(9);
 var ContentStateInlineStyle = __webpack_require__(182);
-var DraftFeatureFlags = __webpack_require__(17);
+var DraftFeatureFlags = __webpack_require__(18);
 var Immutable = __webpack_require__(3);
 
 var applyEntityToContentState = __webpack_require__(183);
 var getCharacterRemovalRange = __webpack_require__(185);
-var getContentStateFragment = __webpack_require__(32);
+var getContentStateFragment = __webpack_require__(33);
 var insertFragmentIntoContentState = __webpack_require__(188);
 var insertTextIntoContentState = __webpack_require__(189);
 var invariant = __webpack_require__(2);
@@ -6349,7 +6349,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var CharacterMetadata = __webpack_require__(9);
 var Immutable = __webpack_require__(3);
 
-var findRangesImmutable = __webpack_require__(27);
+var findRangesImmutable = __webpack_require__(28);
 
 var List = Immutable.List,
     Map = Immutable.Map,
@@ -6899,6 +6899,26 @@ if (process.env.NODE_ENV === 'production') {
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var randomInt = exports.randomInt = function randomInt(max) {
+  var myMax = max || Number.MAX_SAFE_INTEGER;
+  return Math.floor(Math.random() * Math.floor(myMax));
+};
+
+var defaultValidationMessages = exports.defaultValidationMessages = {
+  mandatory: 'This field is required',
+  invalidURL: 'Please enter a valid URL'
+};
+
+/***/ }),
+/* 18 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
 /**
  * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
@@ -6919,7 +6939,7 @@ var DraftFeatureFlags = __webpack_require__(181);
 module.exports = DraftFeatureFlags;
 
 /***/ }),
-/* 18 */
+/* 19 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -6947,7 +6967,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var CharacterMetadata = __webpack_require__(9);
 var Immutable = __webpack_require__(3);
 
-var findRangesImmutable = __webpack_require__(27);
+var findRangesImmutable = __webpack_require__(28);
 
 var List = Immutable.List,
     Map = Immutable.Map,
@@ -7064,7 +7084,7 @@ function haveEqualEntity(charA, charB) {
 module.exports = ContentBlock;
 
 /***/ }),
-/* 19 */
+/* 20 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -7283,7 +7303,7 @@ module.exports = UnicodeUtils;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 20 */
+/* 21 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -7293,11 +7313,11 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _toDate = __webpack_require__(38);
+var _toDate = __webpack_require__(39);
 
 var _toDate2 = _interopRequireDefault(_toDate);
 
-var _toFloat = __webpack_require__(55);
+var _toFloat = __webpack_require__(56);
 
 var _toFloat2 = _interopRequireDefault(_toFloat);
 
@@ -7333,11 +7353,11 @@ var _isMACAddress = __webpack_require__(112);
 
 var _isMACAddress2 = _interopRequireDefault(_isMACAddress);
 
-var _isIP = __webpack_require__(57);
+var _isIP = __webpack_require__(58);
 
 var _isIP2 = _interopRequireDefault(_isIP);
 
-var _isFQDN = __webpack_require__(40);
+var _isFQDN = __webpack_require__(41);
 
 var _isFQDN2 = _interopRequireDefault(_isFQDN);
 
@@ -7373,11 +7393,11 @@ var _isAscii = __webpack_require__(120);
 
 var _isAscii2 = _interopRequireDefault(_isAscii);
 
-var _isFullWidth = __webpack_require__(59);
+var _isFullWidth = __webpack_require__(60);
 
 var _isFullWidth2 = _interopRequireDefault(_isFullWidth);
 
-var _isHalfWidth = __webpack_require__(60);
+var _isHalfWidth = __webpack_require__(61);
 
 var _isHalfWidth2 = _interopRequireDefault(_isHalfWidth);
 
@@ -7393,7 +7413,7 @@ var _isSurrogatePair = __webpack_require__(123);
 
 var _isSurrogatePair2 = _interopRequireDefault(_isSurrogatePair);
 
-var _isInt = __webpack_require__(58);
+var _isInt = __webpack_require__(59);
 
 var _isInt2 = _interopRequireDefault(_isInt);
 
@@ -7405,7 +7425,7 @@ var _isDecimal = __webpack_require__(125);
 
 var _isDecimal2 = _interopRequireDefault(_isDecimal);
 
-var _isHexadecimal = __webpack_require__(61);
+var _isHexadecimal = __webpack_require__(62);
 
 var _isHexadecimal2 = _interopRequireDefault(_isHexadecimal);
 
@@ -7441,7 +7461,7 @@ var _isLength = __webpack_require__(133);
 
 var _isLength2 = _interopRequireDefault(_isLength);
 
-var _isByteLength = __webpack_require__(56);
+var _isByteLength = __webpack_require__(57);
 
 var _isByteLength2 = _interopRequireDefault(_isByteLength);
 
@@ -7517,11 +7537,11 @@ var _isPostalCode = __webpack_require__(151);
 
 var _isPostalCode2 = _interopRequireDefault(_isPostalCode);
 
-var _ltrim = __webpack_require__(62);
+var _ltrim = __webpack_require__(63);
 
 var _ltrim2 = _interopRequireDefault(_ltrim);
 
-var _rtrim = __webpack_require__(63);
+var _rtrim = __webpack_require__(64);
 
 var _rtrim2 = _interopRequireDefault(_rtrim);
 
@@ -7545,7 +7565,7 @@ var _whitelist = __webpack_require__(156);
 
 var _whitelist2 = _interopRequireDefault(_whitelist);
 
-var _blacklist = __webpack_require__(64);
+var _blacklist = __webpack_require__(65);
 
 var _blacklist2 = _interopRequireDefault(_blacklist);
 
@@ -7557,7 +7577,7 @@ var _normalizeEmail = __webpack_require__(158);
 
 var _normalizeEmail2 = _interopRequireDefault(_normalizeEmail);
 
-var _toString = __webpack_require__(39);
+var _toString = __webpack_require__(40);
 
 var _toString2 = _interopRequireDefault(_toString);
 
@@ -7640,7 +7660,7 @@ exports.default = validator;
 module.exports = exports['default'];
 
 /***/ }),
-/* 21 */
+/* 22 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -7664,7 +7684,7 @@ function merge() {
 module.exports = exports['default'];
 
 /***/ }),
-/* 22 */
+/* 23 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -7680,7 +7700,7 @@ var _react = __webpack_require__(4);
 
 var _react2 = _interopRequireDefault(_react);
 
-var _reactFontawesome = __webpack_require__(41);
+var _reactFontawesome = __webpack_require__(42);
 
 var _reactFontawesome2 = _interopRequireDefault(_reactFontawesome);
 
@@ -7688,7 +7708,7 @@ var _reactTooltip = __webpack_require__(159);
 
 var _reactTooltip2 = _interopRequireDefault(_reactTooltip);
 
-var _utils = __webpack_require__(73);
+var _utils = __webpack_require__(17);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7727,7 +7747,7 @@ var TooltipLink = function (_PureComponent) {
 exports.default = TooltipLink;
 
 /***/ }),
-/* 23 */
+/* 24 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -7867,7 +7887,7 @@ var SelectionState = function (_SelectionStateRecord) {
 module.exports = SelectionState;
 
 /***/ }),
-/* 24 */
+/* 25 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -7912,7 +7932,7 @@ function replace(str) {
 module.exports = cx;
 
 /***/ }),
-/* 25 */
+/* 26 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -7955,7 +7975,7 @@ function containsNode(outerNode, innerNode) {
 module.exports = containsNode;
 
 /***/ }),
-/* 26 */
+/* 27 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -7990,7 +8010,7 @@ var BlockMapBuilder = {
 module.exports = BlockMapBuilder;
 
 /***/ }),
-/* 27 */
+/* 28 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8039,7 +8059,7 @@ function findRangesImmutable(haystack, areEqualFn, filterFn, foundFn) {
 module.exports = findRangesImmutable;
 
 /***/ }),
-/* 28 */
+/* 29 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8069,7 +8089,7 @@ function isEventHandled(value) {
 module.exports = isEventHandled;
 
 /***/ }),
-/* 29 */
+/* 30 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8118,7 +8138,7 @@ function removeTextWithStrategy(editorState, strategy, direction) {
 module.exports = removeTextWithStrategy;
 
 /***/ }),
-/* 30 */
+/* 31 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8220,7 +8240,7 @@ alphanumeric['pt-BR'] = alphanumeric['pt-PT'];
 decimal['pt-BR'] = decimal['pt-PT'];
 
 /***/ }),
-/* 31 */
+/* 32 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8262,7 +8282,7 @@ function getActiveElement(doc) /*?DOMElement*/{
 module.exports = getActiveElement;
 
 /***/ }),
-/* 32 */
+/* 33 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8332,7 +8352,7 @@ var getContentStateFragment = function getContentStateFragment(contentState, sel
 module.exports = getContentStateFragment;
 
 /***/ }),
-/* 33 */
+/* 34 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8533,7 +8553,7 @@ module.exports = DraftEntity;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 34 */
+/* 35 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8576,7 +8596,7 @@ var DraftOffsetKey = {
 module.exports = DraftOffsetKey;
 
 /***/ }),
-/* 35 */
+/* 36 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8645,7 +8665,7 @@ module.exports = warning;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 36 */
+/* 37 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8664,7 +8684,7 @@ module.exports = ReactPropTypesSecret;
 
 
 /***/ }),
-/* 37 */
+/* 38 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8686,15 +8706,15 @@ var _propTypes = __webpack_require__(8);
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _validator = __webpack_require__(20);
+var _validator = __webpack_require__(21);
 
 var _validator2 = _interopRequireDefault(_validator);
 
-var _tooltipLink = __webpack_require__(22);
+var _tooltipLink = __webpack_require__(23);
 
 var _tooltipLink2 = _interopRequireDefault(_tooltipLink);
 
-var _utils = __webpack_require__(73);
+var _utils = __webpack_require__(17);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -8809,7 +8829,7 @@ Input.propTypes = {
 exports.default = Input;
 
 /***/ }),
-/* 38 */
+/* 39 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8834,7 +8854,7 @@ function toDate(date) {
 module.exports = exports['default'];
 
 /***/ }),
-/* 39 */
+/* 40 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8862,7 +8882,7 @@ function toString(input) {
 module.exports = exports['default'];
 
 /***/ }),
-/* 40 */
+/* 41 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -8877,7 +8897,7 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _merge = __webpack_require__(21);
+var _merge = __webpack_require__(22);
 
 var _merge2 = _interopRequireDefault(_merge);
 
@@ -8929,11 +8949,11 @@ function isFQDN(str, options) {
 module.exports = exports['default'];
 
 /***/ }),
-/* 41 */
+/* 42 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(global, process) {(function (global, factory) {
-	 true ? module.exports = factory(__webpack_require__(65), __webpack_require__(8), __webpack_require__(4)) :
+	 true ? module.exports = factory(__webpack_require__(66), __webpack_require__(8), __webpack_require__(4)) :
 	typeof define === 'function' && define.amd ? define(['@fortawesome/fontawesome', 'prop-types', 'react'], factory) :
 	(global['react-fontawesome'] = factory(global.FontAwesome,global.PropTypes,global.React));
 }(this, (function (fontawesome,PropTypes,React) { 'use strict';
@@ -9519,7 +9539,7 @@ return FontAwesomeIcon$1;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12), __webpack_require__(1)))
 
 /***/ }),
-/* 42 */
+/* 43 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -9544,17 +9564,17 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var BlockMapBuilder = __webpack_require__(26);
+var BlockMapBuilder = __webpack_require__(27);
 var CharacterMetadata = __webpack_require__(9);
-var ContentBlock = __webpack_require__(18);
+var ContentBlock = __webpack_require__(19);
 var ContentBlockNode = __webpack_require__(10);
-var DraftEntity = __webpack_require__(33);
-var DraftFeatureFlags = __webpack_require__(17);
+var DraftEntity = __webpack_require__(34);
+var DraftFeatureFlags = __webpack_require__(18);
 var Immutable = __webpack_require__(3);
-var SelectionState = __webpack_require__(23);
+var SelectionState = __webpack_require__(24);
 
 var generateRandomKey = __webpack_require__(14);
-var sanitizeDraftText = __webpack_require__(43);
+var sanitizeDraftText = __webpack_require__(44);
 
 var List = Immutable.List,
     Record = Immutable.Record,
@@ -9723,7 +9743,7 @@ var ContentState = function (_ContentStateRecord) {
 module.exports = ContentState;
 
 /***/ }),
-/* 43 */
+/* 44 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -9751,7 +9771,7 @@ function sanitizeDraftText(input) {
 module.exports = sanitizeDraftText;
 
 /***/ }),
-/* 44 */
+/* 45 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -9864,7 +9884,7 @@ module.exports = UnicodeBidiDirection;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 45 */
+/* 46 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -9888,7 +9908,7 @@ var _require = __webpack_require__(3),
 
 var React = __webpack_require__(4);
 
-var cx = __webpack_require__(24);
+var cx = __webpack_require__(25);
 
 var UL_WRAP = React.createElement('ul', { className: cx('public/DraftStyleDefault/ul') });
 var OL_WRAP = React.createElement('ol', { className: cx('public/DraftStyleDefault/ol') });
@@ -9940,7 +9960,7 @@ var DefaultDraftBlockRenderMap = Map({
 module.exports = DefaultDraftBlockRenderMap;
 
 /***/ }),
-/* 46 */
+/* 47 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -9980,7 +10000,7 @@ module.exports = {
 };
 
 /***/ }),
-/* 47 */
+/* 48 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10044,7 +10064,7 @@ function filterKey(entityMap, entityKey) {
 module.exports = getEntityKeyForSelection;
 
 /***/ }),
-/* 48 */
+/* 49 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10112,7 +10132,7 @@ var Style = {
 module.exports = Style;
 
 /***/ }),
-/* 49 */
+/* 50 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10163,7 +10183,7 @@ function getScrollPosition(scrollable) {
 module.exports = getScrollPosition;
 
 /***/ }),
-/* 50 */
+/* 51 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10202,7 +10222,7 @@ function findAncestorOffsetKey(node) {
 module.exports = findAncestorOffsetKey;
 
 /***/ }),
-/* 51 */
+/* 52 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10247,7 +10267,7 @@ var KeyBindingUtil = {
 module.exports = KeyBindingUtil;
 
 /***/ }),
-/* 52 */
+/* 53 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10306,7 +10326,7 @@ function moveSelectionBackward(editorState, maxDistance) {
 module.exports = moveSelectionBackward;
 
 /***/ }),
-/* 53 */
+/* 54 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10355,7 +10375,7 @@ exports.default = function (contentState, anchorKey, focusKey) {
 };
 
 /***/ }),
-/* 54 */
+/* 55 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10370,8 +10390,8 @@ exports.default = function (contentState, anchorKey, focusKey) {
 
 if (process.env.NODE_ENV !== 'production') {
   var invariant = __webpack_require__(2);
-  var warning = __webpack_require__(35);
-  var ReactPropTypesSecret = __webpack_require__(36);
+  var warning = __webpack_require__(36);
+  var ReactPropTypesSecret = __webpack_require__(37);
   var loggedTypeFailures = {};
 }
 
@@ -10422,7 +10442,7 @@ module.exports = checkPropTypes;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 55 */
+/* 56 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10446,7 +10466,7 @@ function toFloat(str) {
 module.exports = exports['default'];
 
 /***/ }),
-/* 56 */
+/* 57 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10485,7 +10505,7 @@ function isByteLength(str, options) {
 module.exports = exports['default'];
 
 /***/ }),
-/* 57 */
+/* 58 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10572,7 +10592,7 @@ function isIP(str) {
 module.exports = exports['default'];
 
 /***/ }),
-/* 58 */
+/* 59 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10611,7 +10631,7 @@ function isInt(str, options) {
 module.exports = exports['default'];
 
 /***/ }),
-/* 59 */
+/* 60 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10637,7 +10657,7 @@ function isFullWidth(str) {
 }
 
 /***/ }),
-/* 60 */
+/* 61 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10663,7 +10683,7 @@ function isHalfWidth(str) {
 }
 
 /***/ }),
-/* 61 */
+/* 62 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10689,7 +10709,7 @@ function isHexadecimal(str) {
 module.exports = exports['default'];
 
 /***/ }),
-/* 62 */
+/* 63 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10714,7 +10734,7 @@ function ltrim(str, chars) {
 module.exports = exports['default'];
 
 /***/ }),
-/* 63 */
+/* 64 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10745,7 +10765,7 @@ function rtrim(str, chars) {
 module.exports = exports['default'];
 
 /***/ }),
-/* 64 */
+/* 65 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -10769,7 +10789,7 @@ function blacklist(str, chars) {
 module.exports = exports['default'];
 
 /***/ }),
-/* 65 */
+/* 66 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -12592,7 +12612,7 @@ var config = api$1.config;
 /* WEBPACK VAR INJECTION */}.call(__webpack_exports__, __webpack_require__(1)))
 
 /***/ }),
-/* 66 */
+/* 67 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -12631,7 +12651,7 @@ var ExecutionEnvironment = {
 module.exports = ExecutionEnvironment;
 
 /***/ }),
-/* 67 */
+/* 68 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -12702,7 +12722,7 @@ function shallowEqual(objA, objB) {
 module.exports = shallowEqual;
 
 /***/ }),
-/* 68 */
+/* 69 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -12726,7 +12746,7 @@ module.exports = emptyObject;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 69 */
+/* 70 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -12762,7 +12782,7 @@ function hyphenate(string) {
 module.exports = hyphenate;
 
 /***/ }),
-/* 70 */
+/* 71 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -12797,7 +12817,7 @@ function camelize(string) {
 module.exports = camelize;
 
 /***/ }),
-/* 71 */
+/* 72 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
@@ -12856,7 +12876,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
 
 
 /***/ }),
-/* 72 */
+/* 73 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -12872,26 +12892,6 @@ exports.default = {
     REBUILD: '__react_tooltip_rebuild_event',
     SHOW: '__react_tooltip_show_event'
   }
-};
-
-/***/ }),
-/* 73 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-var randomInt = exports.randomInt = function randomInt(max) {
-  var myMax = max || Number.MAX_SAFE_INTEGER;
-  return Math.floor(Math.random() * Math.floor(myMax));
-};
-
-var defaultValidationMessages = exports.defaultValidationMessages = {
-  mandatory: 'This field is required',
-  invalidURL: 'Please enter a valid URL'
 };
 
 /***/ }),
@@ -12915,22 +12915,22 @@ var defaultValidationMessages = exports.defaultValidationMessages = {
 
 
 var AtomicBlockUtils = __webpack_require__(180);
-var BlockMapBuilder = __webpack_require__(26);
+var BlockMapBuilder = __webpack_require__(27);
 var CharacterMetadata = __webpack_require__(9);
 var CompositeDraftDecorator = __webpack_require__(196);
-var ContentBlock = __webpack_require__(18);
-var ContentState = __webpack_require__(42);
-var DefaultDraftBlockRenderMap = __webpack_require__(45);
+var ContentBlock = __webpack_require__(19);
+var ContentState = __webpack_require__(43);
+var DefaultDraftBlockRenderMap = __webpack_require__(46);
 var DefaultDraftInlineStyle = __webpack_require__(82);
 var DraftEditor = __webpack_require__(197);
 var DraftEditorBlock = __webpack_require__(84);
-var DraftEntity = __webpack_require__(33);
+var DraftEntity = __webpack_require__(34);
 var DraftModifier = __webpack_require__(7);
 var DraftEntityInstance = __webpack_require__(80);
 var EditorState = __webpack_require__(5);
-var KeyBindingUtil = __webpack_require__(51);
+var KeyBindingUtil = __webpack_require__(52);
 var RichTextEditorUtil = __webpack_require__(97);
-var SelectionState = __webpack_require__(23);
+var SelectionState = __webpack_require__(24);
 
 var convertFromDraftStateToRaw = __webpack_require__(255);
 var convertFromHTMLToContentBlocks = __webpack_require__(95);
@@ -13113,7 +13113,7 @@ module.exports = randomizeBlockMapKeys;
 
 var CharacterMetadata = __webpack_require__(9);
 
-var findRangesImmutable = __webpack_require__(27);
+var findRangesImmutable = __webpack_require__(28);
 var invariant = __webpack_require__(2);
 
 function removeEntitiesAtEdges(contentState, selectionState) {
@@ -13323,7 +13323,7 @@ module.exports = getNextDelimiterBlockKey;
 var Immutable = __webpack_require__(3);
 
 var emptyFunction = __webpack_require__(15);
-var findRangesImmutable = __webpack_require__(27);
+var findRangesImmutable = __webpack_require__(28);
 
 var List = Immutable.List,
     Repeat = Immutable.Repeat,
@@ -13520,7 +13520,7 @@ module.exports = DraftEntityInstance;
 
 
 
-var UnicodeBidiDirection = __webpack_require__(44);
+var UnicodeBidiDirection = __webpack_require__(45);
 
 var invariant = __webpack_require__(2);
 
@@ -13784,17 +13784,17 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var DraftEditorLeaf = __webpack_require__(201);
-var DraftOffsetKey = __webpack_require__(34);
+var DraftOffsetKey = __webpack_require__(35);
 var React = __webpack_require__(4);
 var ReactDOM = __webpack_require__(16);
 var Scroll = __webpack_require__(85);
-var Style = __webpack_require__(48);
+var Style = __webpack_require__(49);
 var UnicodeBidi = __webpack_require__(81);
-var UnicodeBidiDirection = __webpack_require__(44);
+var UnicodeBidiDirection = __webpack_require__(45);
 
-var cx = __webpack_require__(24);
+var cx = __webpack_require__(25);
 var getElementPosition = __webpack_require__(212);
-var getScrollPosition = __webpack_require__(49);
+var getScrollPosition = __webpack_require__(50);
 var getViewportDimensions = __webpack_require__(216);
 var invariant = __webpack_require__(2);
 var nullthrows = __webpack_require__(11);
@@ -14430,7 +14430,7 @@ module.exports = getTextContentFromFiles;
 
 
 
-var DraftOffsetKey = __webpack_require__(34);
+var DraftOffsetKey = __webpack_require__(35);
 
 var nullthrows = __webpack_require__(11);
 
@@ -14513,7 +14513,7 @@ module.exports = getUpdatedSelectionState;
 
 
 
-var getContentStateFragment = __webpack_require__(32);
+var getContentStateFragment = __webpack_require__(33);
 
 function getFragmentFromSelection(editorState) {
   var selectionState = editorState.getSelection();
@@ -14617,7 +14617,7 @@ module.exports = getRangeClientRects;
 
 
 
-var findAncestorOffsetKey = __webpack_require__(50);
+var findAncestorOffsetKey = __webpack_require__(51);
 var getSelectionOffsetKeyForNode = __webpack_require__(87);
 var getUpdatedSelectionState = __webpack_require__(89);
 var invariant = __webpack_require__(2);
@@ -14923,11 +14923,11 @@ var _knownListItemDepthCl,
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 var CharacterMetadata = __webpack_require__(9);
-var ContentBlock = __webpack_require__(18);
+var ContentBlock = __webpack_require__(19);
 var ContentBlockNode = __webpack_require__(10);
-var DefaultDraftBlockRenderMap = __webpack_require__(45);
-var DraftEntity = __webpack_require__(33);
-var DraftFeatureFlags = __webpack_require__(17);
+var DefaultDraftBlockRenderMap = __webpack_require__(46);
+var DraftEntity = __webpack_require__(34);
+var DraftFeatureFlags = __webpack_require__(18);
 var Immutable = __webpack_require__(3);
 
 var _require = __webpack_require__(3),
@@ -14935,11 +14935,11 @@ var _require = __webpack_require__(3),
 
 var URI = __webpack_require__(249);
 
-var cx = __webpack_require__(24);
+var cx = __webpack_require__(25);
 var generateRandomKey = __webpack_require__(14);
 var getSafeBodyFromHTML = __webpack_require__(96);
 var invariant = __webpack_require__(2);
-var sanitizeDraftText = __webpack_require__(43);
+var sanitizeDraftText = __webpack_require__(44);
 
 var experimentalTreeDataSupport = DraftFeatureFlags.draft_tree_data_support;
 
@@ -15622,7 +15622,7 @@ module.exports = getSafeBodyFromHTML;
 
 var DraftModifier = __webpack_require__(7);
 var EditorState = __webpack_require__(5);
-var SelectionState = __webpack_require__(23);
+var SelectionState = __webpack_require__(24);
 
 var adjustBlockDepthForContentState = __webpack_require__(250);
 var nullthrows = __webpack_require__(11);
@@ -15936,8 +15936,8 @@ module.exports = RichTextEditorUtil;
 
 
 
-var KeyBindingUtil = __webpack_require__(51);
-var Keys = __webpack_require__(46);
+var KeyBindingUtil = __webpack_require__(52);
+var Keys = __webpack_require__(47);
 var UserAgent = __webpack_require__(13);
 
 var isOSX = UserAgent.isPlatform('Mac OS X');
@@ -16565,7 +16565,7 @@ var _propTypes = __webpack_require__(8);
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _input = __webpack_require__(37);
+var _input = __webpack_require__(38);
 
 var _input2 = _interopRequireDefault(_input);
 
@@ -16617,13 +16617,13 @@ var _externalComponentContainer = __webpack_require__(290);
 
 var _externalComponentContainer2 = _interopRequireDefault(_externalComponentContainer);
 
-var _utils = __webpack_require__(73);
+var _utils = __webpack_require__(17);
 
-var _fontawesome = __webpack_require__(65);
+var _fontawesome = __webpack_require__(66);
 
 var _fontawesome2 = _interopRequireDefault(_fontawesome);
 
-var _reactFontawesome = __webpack_require__(41);
+var _reactFontawesome = __webpack_require__(42);
 
 var _reactFontawesome2 = _interopRequireDefault(_reactFontawesome);
 
@@ -16831,11 +16831,11 @@ exports.Url = _url2.default;
 
 var emptyFunction = __webpack_require__(15);
 var invariant = __webpack_require__(2);
-var warning = __webpack_require__(35);
+var warning = __webpack_require__(36);
 var assign = __webpack_require__(6);
 
-var ReactPropTypesSecret = __webpack_require__(36);
-var checkPropTypes = __webpack_require__(54);
+var ReactPropTypesSecret = __webpack_require__(37);
+var checkPropTypes = __webpack_require__(55);
 
 module.exports = function(isValidElement, throwOnDirectAccess) {
   /* global Symbol */
@@ -17381,7 +17381,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
 
 var emptyFunction = __webpack_require__(15);
 var invariant = __webpack_require__(2);
-var ReactPropTypesSecret = __webpack_require__(36);
+var ReactPropTypesSecret = __webpack_require__(37);
 
 module.exports = function() {
   function shim(props, propName, componentName, location, propFullName, secret) {
@@ -17521,7 +17521,7 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _toString = __webpack_require__(39);
+var _toString = __webpack_require__(40);
 
 var _toString2 = _interopRequireDefault(_toString);
 
@@ -17576,15 +17576,15 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _merge = __webpack_require__(21);
+var _merge = __webpack_require__(22);
 
 var _merge2 = _interopRequireDefault(_merge);
 
-var _isByteLength = __webpack_require__(56);
+var _isByteLength = __webpack_require__(57);
 
 var _isByteLength2 = _interopRequireDefault(_isByteLength);
 
-var _isFQDN = __webpack_require__(40);
+var _isFQDN = __webpack_require__(41);
 
 var _isFQDN2 = _interopRequireDefault(_isFQDN);
 
@@ -17671,15 +17671,15 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _isFQDN = __webpack_require__(40);
+var _isFQDN = __webpack_require__(41);
 
 var _isFQDN2 = _interopRequireDefault(_isFQDN);
 
-var _isIP = __webpack_require__(57);
+var _isIP = __webpack_require__(58);
 
 var _isIP2 = _interopRequireDefault(_isIP);
 
-var _merge = __webpack_require__(21);
+var _merge = __webpack_require__(22);
 
 var _merge2 = _interopRequireDefault(_merge);
 
@@ -17874,7 +17874,7 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _alpha = __webpack_require__(30);
+var _alpha = __webpack_require__(31);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -17905,7 +17905,7 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _alpha = __webpack_require__(30);
+var _alpha = __webpack_require__(31);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -17958,7 +17958,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = isPort;
 
-var _isInt = __webpack_require__(58);
+var _isInt = __webpack_require__(59);
 
 var _isInt2 = _interopRequireDefault(_isInt);
 
@@ -18061,9 +18061,9 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _isFullWidth = __webpack_require__(59);
+var _isFullWidth = __webpack_require__(60);
 
-var _isHalfWidth = __webpack_require__(60);
+var _isHalfWidth = __webpack_require__(61);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -18143,7 +18143,7 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _alpha = __webpack_require__(30);
+var _alpha = __webpack_require__(31);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -18170,7 +18170,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = isDecimal;
 
-var _merge = __webpack_require__(21);
+var _merge = __webpack_require__(22);
 
 var _merge2 = _interopRequireDefault(_merge);
 
@@ -18178,7 +18178,7 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _alpha = __webpack_require__(30);
+var _alpha = __webpack_require__(31);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -18221,7 +18221,7 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _toFloat = __webpack_require__(55);
+var _toFloat = __webpack_require__(56);
 
 var _toFloat2 = _interopRequireDefault(_toFloat);
 
@@ -18498,7 +18498,7 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _isHexadecimal = __webpack_require__(61);
+var _isHexadecimal = __webpack_require__(62);
 
 var _isHexadecimal2 = _interopRequireDefault(_isHexadecimal);
 
@@ -18526,7 +18526,7 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _toDate = __webpack_require__(38);
+var _toDate = __webpack_require__(39);
 
 var _toDate2 = _interopRequireDefault(_toDate);
 
@@ -18558,7 +18558,7 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _toDate = __webpack_require__(38);
+var _toDate = __webpack_require__(39);
 
 var _toDate2 = _interopRequireDefault(_toDate);
 
@@ -18593,7 +18593,7 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _toString = __webpack_require__(39);
+var _toString = __webpack_require__(40);
 
 var _toString2 = _interopRequireDefault(_toString);
 
@@ -18972,7 +18972,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = isCurrency;
 
-var _merge = __webpack_require__(21);
+var _merge = __webpack_require__(22);
 
 var _merge2 = _interopRequireDefault(_merge);
 
@@ -19381,11 +19381,11 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = trim;
 
-var _rtrim = __webpack_require__(63);
+var _rtrim = __webpack_require__(64);
 
 var _rtrim2 = _interopRequireDefault(_rtrim);
 
-var _ltrim = __webpack_require__(62);
+var _ltrim = __webpack_require__(63);
 
 var _ltrim2 = _interopRequireDefault(_ltrim);
 
@@ -19460,7 +19460,7 @@ var _assertString = __webpack_require__(0);
 
 var _assertString2 = _interopRequireDefault(_assertString);
 
-var _blacklist = __webpack_require__(64);
+var _blacklist = __webpack_require__(65);
 
 var _blacklist2 = _interopRequireDefault(_blacklist);
 
@@ -19538,7 +19538,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = normalizeEmail;
 
-var _merge = __webpack_require__(21);
+var _merge = __webpack_require__(22);
 
 var _merge2 = _interopRequireDefault(_merge);
 
@@ -19695,7 +19695,7 @@ var _reactDom = __webpack_require__(16);
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
 
-var _classnames = __webpack_require__(71);
+var _classnames = __webpack_require__(72);
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
@@ -20296,7 +20296,7 @@ module.exports = ReactTooltip;
 /*
  Modernizr 3.0.0pre (Custom Build) | MIT
 */
-var aa=__webpack_require__(2),ba=__webpack_require__(4),m=__webpack_require__(66),p=__webpack_require__(6),v=__webpack_require__(15),da=__webpack_require__(31),ea=__webpack_require__(67),fa=__webpack_require__(25),ha=__webpack_require__(68);
+var aa=__webpack_require__(2),ba=__webpack_require__(4),m=__webpack_require__(67),p=__webpack_require__(6),v=__webpack_require__(15),da=__webpack_require__(32),ea=__webpack_require__(68),fa=__webpack_require__(26),ha=__webpack_require__(69);
 function A(a){for(var b=arguments.length-1,c="https://reactjs.org/docs/error-decoder.html?invariant="+a,d=0;d<b;d++)c+="&args[]="+encodeURIComponent(arguments[d+1]);aa(!1,"Minified React error #"+a+"; visit %s for the full message or use the non-minified dev environment for full errors and additional helpful warnings. ",c)}ba?void 0:A("227");
 function ia(a,b,c,d,e,f,g,h,k){this._hasCaughtError=!1;this._caughtError=null;var n=Array.prototype.slice.call(arguments,3);try{b.apply(c,n)}catch(r){this._caughtError=r,this._hasCaughtError=!0}}
 var B={_caughtError:null,_hasCaughtError:!1,_rethrowError:null,_hasRethrowError:!1,invokeGuardedCallback:function(a,b,c,d,e,f,g,h,k){ia.apply(B,arguments)},invokeGuardedCallbackAndCatchFirstError:function(a,b,c,d,e,f,g,h,k){B.invokeGuardedCallback.apply(this,arguments);if(B.hasCaughtError()){var n=B.clearCaughtError();B._hasRethrowError||(B._hasRethrowError=!0,B._rethrowError=n)}},rethrowCaughtError:function(){return ka.apply(B,arguments)},hasCaughtError:function(){return B._hasCaughtError},clearCaughtError:function(){if(B._hasCaughtError){var a=
@@ -20606,15 +20606,15 @@ if (process.env.NODE_ENV !== "production") {
 
 var invariant = __webpack_require__(2);
 var React = __webpack_require__(4);
-var warning = __webpack_require__(35);
-var ExecutionEnvironment = __webpack_require__(66);
+var warning = __webpack_require__(36);
+var ExecutionEnvironment = __webpack_require__(67);
 var _assign = __webpack_require__(6);
 var emptyFunction = __webpack_require__(15);
-var checkPropTypes = __webpack_require__(54);
-var getActiveElement = __webpack_require__(31);
-var shallowEqual = __webpack_require__(67);
-var containsNode = __webpack_require__(25);
-var emptyObject = __webpack_require__(68);
+var checkPropTypes = __webpack_require__(55);
+var getActiveElement = __webpack_require__(32);
+var shallowEqual = __webpack_require__(68);
+var containsNode = __webpack_require__(26);
+var emptyObject = __webpack_require__(69);
 var hyphenateStyleName = __webpack_require__(164);
 var camelizeStyleName = __webpack_require__(165);
 
@@ -38036,7 +38036,7 @@ module.exports = reactDom;
 
 
 
-var hyphenate = __webpack_require__(69);
+var hyphenate = __webpack_require__(70);
 
 var msPattern = /^ms-/;
 
@@ -38078,7 +38078,7 @@ module.exports = hyphenateStyleName;
 
 
 
-var camelize = __webpack_require__(70);
+var camelize = __webpack_require__(71);
 
 var msPattern = /^-ms-/;
 
@@ -38165,7 +38165,7 @@ exports.default = function (target) {
   };
 };
 
-var _constant = __webpack_require__(72);
+var _constant = __webpack_require__(73);
 
 var _constant2 = _interopRequireDefault(_constant);
 
@@ -38237,7 +38237,7 @@ exports.default = function (target) {
   };
 };
 
-var _constant = __webpack_require__(72);
+var _constant = __webpack_require__(73);
 
 var _constant2 = _interopRequireDefault(_constant);
 
@@ -38933,11 +38933,11 @@ var _propTypes = __webpack_require__(8);
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _validator = __webpack_require__(20);
+var _validator = __webpack_require__(21);
 
 var _validator2 = _interopRequireDefault(_validator);
 
-var _utils = __webpack_require__(73);
+var _utils = __webpack_require__(17);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -39080,15 +39080,15 @@ var _propTypes = __webpack_require__(8);
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _validator = __webpack_require__(20);
+var _validator = __webpack_require__(21);
 
 var _validator2 = _interopRequireDefault(_validator);
 
-var _tooltipLink = __webpack_require__(22);
+var _tooltipLink = __webpack_require__(23);
 
 var _tooltipLink2 = _interopRequireDefault(_tooltipLink);
 
-var _utils = __webpack_require__(73);
+var _utils = __webpack_require__(17);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -39231,19 +39231,19 @@ var _draftJs = __webpack_require__(74);
 
 var _draftJsExportHtml = __webpack_require__(265);
 
-var _validator = __webpack_require__(20);
+var _validator = __webpack_require__(21);
 
 var _validator2 = _interopRequireDefault(_validator);
 
-var _reactFontawesome = __webpack_require__(41);
+var _reactFontawesome = __webpack_require__(42);
 
 var _reactFontawesome2 = _interopRequireDefault(_reactFontawesome);
 
-var _tooltipLink = __webpack_require__(22);
+var _tooltipLink = __webpack_require__(23);
 
 var _tooltipLink2 = _interopRequireDefault(_tooltipLink);
 
-var _utils = __webpack_require__(73);
+var _utils = __webpack_require__(17);
 
 __webpack_require__(275);
 
@@ -39561,15 +39561,15 @@ var _assign = __webpack_require__(6);
 
 var _extends = _assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var BlockMapBuilder = __webpack_require__(26);
+var BlockMapBuilder = __webpack_require__(27);
 var CharacterMetadata = __webpack_require__(9);
-var ContentBlock = __webpack_require__(18);
+var ContentBlock = __webpack_require__(19);
 var ContentBlockNode = __webpack_require__(10);
-var DraftFeatureFlags = __webpack_require__(17);
+var DraftFeatureFlags = __webpack_require__(18);
 var DraftModifier = __webpack_require__(7);
 var EditorState = __webpack_require__(5);
 var Immutable = __webpack_require__(3);
-var SelectionState = __webpack_require__(23);
+var SelectionState = __webpack_require__(24);
 
 var generateRandomKey = __webpack_require__(14);
 var moveBlockInContentState = __webpack_require__(195);
@@ -40155,7 +40155,7 @@ module.exports = getRangesForDraftEntity;
 
 
 
-var BlockMapBuilder = __webpack_require__(26);
+var BlockMapBuilder = __webpack_require__(27);
 var ContentBlockNode = __webpack_require__(10);
 var Immutable = __webpack_require__(3);
 
@@ -41052,7 +41052,7 @@ module.exports = EditorBidiService;
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var UnicodeBidi = __webpack_require__(81);
-var UnicodeBidiDirection = __webpack_require__(44);
+var UnicodeBidiDirection = __webpack_require__(45);
 
 var invariant = __webpack_require__(2);
 
@@ -41458,7 +41458,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var DefaultDraftBlockRenderMap = __webpack_require__(45);
+var DefaultDraftBlockRenderMap = __webpack_require__(46);
 var DefaultDraftInlineStyle = __webpack_require__(82);
 var DraftEditorCompositionHandler = __webpack_require__(198);
 var DraftEditorContents = __webpack_require__(199);
@@ -41469,14 +41469,14 @@ var EditorState = __webpack_require__(5);
 var React = __webpack_require__(4);
 var ReactDOM = __webpack_require__(16);
 var Scroll = __webpack_require__(85);
-var Style = __webpack_require__(48);
+var Style = __webpack_require__(49);
 var UserAgent = __webpack_require__(13);
 
-var cx = __webpack_require__(24);
+var cx = __webpack_require__(25);
 var emptyFunction = __webpack_require__(15);
 var generateRandomKey = __webpack_require__(14);
 var getDefaultKeyBinding = __webpack_require__(98);
-var getScrollPosition = __webpack_require__(49);
+var getScrollPosition = __webpack_require__(50);
 var invariant = __webpack_require__(2);
 var nullthrows = __webpack_require__(11);
 
@@ -41926,13 +41926,13 @@ module.exports = DraftEditor;
 
 
 
-var DraftFeatureFlags = __webpack_require__(17);
+var DraftFeatureFlags = __webpack_require__(18);
 var DraftModifier = __webpack_require__(7);
 var EditorState = __webpack_require__(5);
-var Keys = __webpack_require__(46);
+var Keys = __webpack_require__(47);
 
-var getEntityKeyForSelection = __webpack_require__(47);
-var isEventHandled = __webpack_require__(28);
+var getEntityKeyForSelection = __webpack_require__(48);
+var isEventHandled = __webpack_require__(29);
 var isSelectionAtLeafStart = __webpack_require__(83);
 
 /**
@@ -42142,11 +42142,11 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var DraftEditorBlock = __webpack_require__(84);
-var DraftOffsetKey = __webpack_require__(34);
+var DraftOffsetKey = __webpack_require__(35);
 var EditorState = __webpack_require__(5);
 var React = __webpack_require__(4);
 
-var cx = __webpack_require__(24);
+var cx = __webpack_require__(25);
 var joinClasses = __webpack_require__(217);
 var nullthrows = __webpack_require__(11);
 
@@ -44353,8 +44353,8 @@ module.exports = memoizeStringOnly;
 
 var DraftJsDebugLogging = __webpack_require__(210);
 
-var containsNode = __webpack_require__(25);
-var getActiveElement = __webpack_require__(31);
+var containsNode = __webpack_require__(26);
+var getActiveElement = __webpack_require__(32);
 var invariant = __webpack_require__(2);
 
 function getAnonymizedDOM(node, getNodeLabels) {
@@ -44623,8 +44623,8 @@ module.exports = {
  * @typechecks
  */
 
-var camelize = __webpack_require__(70);
-var hyphenate = __webpack_require__(69);
+var camelize = __webpack_require__(71);
+var hyphenate = __webpack_require__(70);
 
 function asString(value) /*?string*/{
   return value == null ? value : String(value);
@@ -44717,7 +44717,7 @@ module.exports = getElementPosition;
  * @typechecks
  */
 
-var containsNode = __webpack_require__(25);
+var containsNode = __webpack_require__(26);
 
 /**
  * Gets an element's bounding rect in pixels relative to the viewport.
@@ -44964,10 +44964,10 @@ var DataTransfer = __webpack_require__(86);
 var DraftModifier = __webpack_require__(7);
 var EditorState = __webpack_require__(5);
 
-var findAncestorOffsetKey = __webpack_require__(50);
+var findAncestorOffsetKey = __webpack_require__(51);
 var getTextContentFromFiles = __webpack_require__(88);
 var getUpdatedSelectionState = __webpack_require__(89);
-var isEventHandled = __webpack_require__(28);
+var isEventHandled = __webpack_require__(29);
 var nullthrows = __webpack_require__(11);
 
 /**
@@ -45298,8 +45298,8 @@ var DraftModifier = __webpack_require__(7);
 var EditorState = __webpack_require__(5);
 var UserAgent = __webpack_require__(13);
 
-var getEntityKeyForSelection = __webpack_require__(47);
-var isEventHandled = __webpack_require__(28);
+var getEntityKeyForSelection = __webpack_require__(48);
+var isEventHandled = __webpack_require__(29);
 var isSelectionAtLeafStart = __webpack_require__(83);
 var nullthrows = __webpack_require__(11);
 var setImmediate = __webpack_require__(223);
@@ -45687,8 +45687,8 @@ module.exports = global.setImmediate;
 
 var EditorState = __webpack_require__(5);
 
-var containsNode = __webpack_require__(25);
-var getActiveElement = __webpack_require__(31);
+var containsNode = __webpack_require__(26);
+var getActiveElement = __webpack_require__(32);
 
 function editOnBlur(editor, e) {
   // In a contentEditable element, when you select a range and then click
@@ -45820,10 +45820,10 @@ module.exports = editOnCopy;
 
 var DraftModifier = __webpack_require__(7);
 var EditorState = __webpack_require__(5);
-var Style = __webpack_require__(48);
+var Style = __webpack_require__(49);
 
 var getFragmentFromSelection = __webpack_require__(90);
-var getScrollPosition = __webpack_require__(49);
+var getScrollPosition = __webpack_require__(50);
 
 /**
  * On `cut` events, native behavior is allowed to occur so that the system
@@ -46006,13 +46006,13 @@ module.exports = editOnFocus;
 
 
 
-var DraftFeatureFlags = __webpack_require__(17);
+var DraftFeatureFlags = __webpack_require__(18);
 var DraftModifier = __webpack_require__(7);
-var DraftOffsetKey = __webpack_require__(34);
+var DraftOffsetKey = __webpack_require__(35);
 var EditorState = __webpack_require__(5);
 var UserAgent = __webpack_require__(13);
 
-var findAncestorOffsetKey = __webpack_require__(50);
+var findAncestorOffsetKey = __webpack_require__(51);
 var nullthrows = __webpack_require__(11);
 
 var isGecko = UserAgent.isEngine('Gecko');
@@ -46187,12 +46187,12 @@ module.exports = editOnInput;
 
 var DraftModifier = __webpack_require__(7);
 var EditorState = __webpack_require__(5);
-var KeyBindingUtil = __webpack_require__(51);
-var Keys = __webpack_require__(46);
+var KeyBindingUtil = __webpack_require__(52);
+var Keys = __webpack_require__(47);
 var SecondaryClipboard = __webpack_require__(234);
 var UserAgent = __webpack_require__(13);
 
-var isEventHandled = __webpack_require__(28);
+var isEventHandled = __webpack_require__(29);
 var keyCommandBackspaceToStartOfLine = __webpack_require__(235);
 var keyCommandBackspaceWord = __webpack_require__(237);
 var keyCommandDeleteWord = __webpack_require__(239);
@@ -46348,7 +46348,7 @@ module.exports = editOnKeyDown;
 var DraftModifier = __webpack_require__(7);
 var EditorState = __webpack_require__(5);
 
-var getContentStateFragment = __webpack_require__(32);
+var getContentStateFragment = __webpack_require__(33);
 var nullthrows = __webpack_require__(11);
 
 var clipboard = null;
@@ -46425,8 +46425,8 @@ var EditorState = __webpack_require__(5);
 
 var expandRangeToStartOfLine = __webpack_require__(236);
 var getDraftEditorSelectionWithNodes = __webpack_require__(92);
-var moveSelectionBackward = __webpack_require__(52);
-var removeTextWithStrategy = __webpack_require__(29);
+var moveSelectionBackward = __webpack_require__(53);
+var removeTextWithStrategy = __webpack_require__(30);
 
 function keyCommandBackspaceToStartOfLine(editorState) {
   var afterRemoval = removeTextWithStrategy(editorState, function (strategyState) {
@@ -46472,7 +46472,7 @@ module.exports = keyCommandBackspaceToStartOfLine;
  * 
  */
 
-var UnicodeUtils = __webpack_require__(19);
+var UnicodeUtils = __webpack_require__(20);
 
 var getRangeClientRects = __webpack_require__(91);
 var invariant = __webpack_require__(2);
@@ -46674,8 +46674,8 @@ module.exports = expandRangeToStartOfLine;
 var DraftRemovableWord = __webpack_require__(93);
 var EditorState = __webpack_require__(5);
 
-var moveSelectionBackward = __webpack_require__(52);
-var removeTextWithStrategy = __webpack_require__(29);
+var moveSelectionBackward = __webpack_require__(53);
+var removeTextWithStrategy = __webpack_require__(30);
 
 /**
  * Delete the word that is left of the cursor, as well as any spaces or
@@ -46770,7 +46770,7 @@ var DraftRemovableWord = __webpack_require__(93);
 var EditorState = __webpack_require__(5);
 
 var moveSelectionForward = __webpack_require__(94);
-var removeTextWithStrategy = __webpack_require__(29);
+var removeTextWithStrategy = __webpack_require__(30);
 
 /**
  * Delete the word that is right of the cursor, as well as any spaces or
@@ -46937,10 +46937,10 @@ module.exports = keyCommandMoveSelectionToStartOfBlock;
 
 
 var EditorState = __webpack_require__(5);
-var UnicodeUtils = __webpack_require__(19);
+var UnicodeUtils = __webpack_require__(20);
 
-var moveSelectionBackward = __webpack_require__(52);
-var removeTextWithStrategy = __webpack_require__(29);
+var moveSelectionBackward = __webpack_require__(53);
+var removeTextWithStrategy = __webpack_require__(30);
 
 /**
  * Remove the selected range. If the cursor is collapsed, remove the preceding
@@ -46988,10 +46988,10 @@ module.exports = keyCommandPlainBackspace;
 
 
 var EditorState = __webpack_require__(5);
-var UnicodeUtils = __webpack_require__(19);
+var UnicodeUtils = __webpack_require__(20);
 
 var moveSelectionForward = __webpack_require__(94);
-var removeTextWithStrategy = __webpack_require__(29);
+var removeTextWithStrategy = __webpack_require__(30);
 
 /**
  * Remove the selected range. If the cursor is collapsed, remove the following
@@ -47042,7 +47042,7 @@ module.exports = keyCommandPlainDelete;
 var DraftModifier = __webpack_require__(7);
 var EditorState = __webpack_require__(5);
 
-var getContentStateFragment = __webpack_require__(32);
+var getContentStateFragment = __webpack_require__(33);
 
 /**
  * Transpose the characters on either side of a collapsed cursor, or
@@ -47179,7 +47179,7 @@ module.exports = keyCommandUndo;
 
 
 
-var BlockMapBuilder = __webpack_require__(26);
+var BlockMapBuilder = __webpack_require__(27);
 var CharacterMetadata = __webpack_require__(9);
 var DataTransfer = __webpack_require__(86);
 var DraftModifier = __webpack_require__(7);
@@ -47187,9 +47187,9 @@ var DraftPasteProcessor = __webpack_require__(248);
 var EditorState = __webpack_require__(5);
 var RichTextEditorUtil = __webpack_require__(97);
 
-var getEntityKeyForSelection = __webpack_require__(47);
+var getEntityKeyForSelection = __webpack_require__(48);
 var getTextContentFromFiles = __webpack_require__(88);
-var isEventHandled = __webpack_require__(28);
+var isEventHandled = __webpack_require__(29);
 var splitTextIntoTextBlocks = __webpack_require__(251);
 
 /**
@@ -47355,15 +47355,15 @@ var _assign = __webpack_require__(6);
 var _extends = _assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 var CharacterMetadata = __webpack_require__(9);
-var ContentBlock = __webpack_require__(18);
+var ContentBlock = __webpack_require__(19);
 var ContentBlockNode = __webpack_require__(10);
-var DraftFeatureFlags = __webpack_require__(17);
+var DraftFeatureFlags = __webpack_require__(18);
 var Immutable = __webpack_require__(3);
 
 var convertFromHTMLtoContentBlocks = __webpack_require__(95);
 var generateRandomKey = __webpack_require__(14);
 var getSafeBodyFromHTML = __webpack_require__(96);
-var sanitizeDraftText = __webpack_require__(43);
+var sanitizeDraftText = __webpack_require__(44);
 
 var List = Immutable.List,
     Repeat = Immutable.Repeat;
@@ -47638,7 +47638,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 var React = __webpack_require__(4);
 
-var cx = __webpack_require__(24);
+var cx = __webpack_require__(25);
 
 /**
  * This component is responsible for rendering placeholder text for the
@@ -47714,7 +47714,7 @@ var _assign = __webpack_require__(6);
 
 var _extends = _assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var ContentBlock = __webpack_require__(18);
+var ContentBlock = __webpack_require__(19);
 var ContentBlockNode = __webpack_require__(10);
 var DraftStringKey = __webpack_require__(99);
 
@@ -47858,7 +47858,7 @@ module.exports = convertFromDraftStateToRaw;
 
 
 var DraftStringKey = __webpack_require__(99);
-var UnicodeUtils = __webpack_require__(19);
+var UnicodeUtils = __webpack_require__(20);
 
 var strlen = UnicodeUtils.strlen;
 
@@ -47905,9 +47905,9 @@ module.exports = encodeEntityRanges;
 
 
 
-var UnicodeUtils = __webpack_require__(19);
+var UnicodeUtils = __webpack_require__(20);
 
-var findRangesImmutable = __webpack_require__(27);
+var findRangesImmutable = __webpack_require__(28);
 
 var areEqual = function areEqual(a, b) {
   return a === b;
@@ -47984,14 +47984,14 @@ var _assign = __webpack_require__(6);
 
 var _extends = _assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var ContentBlock = __webpack_require__(18);
+var ContentBlock = __webpack_require__(19);
 var ContentBlockNode = __webpack_require__(10);
-var ContentState = __webpack_require__(42);
-var DraftEntity = __webpack_require__(33);
-var DraftFeatureFlags = __webpack_require__(17);
+var ContentState = __webpack_require__(43);
+var DraftEntity = __webpack_require__(34);
+var DraftFeatureFlags = __webpack_require__(18);
 var DraftTreeAdapter = __webpack_require__(259);
 var Immutable = __webpack_require__(3);
-var SelectionState = __webpack_require__(23);
+var SelectionState = __webpack_require__(24);
 
 var createCharacterList = __webpack_require__(260);
 var decodeEntityRanges = __webpack_require__(261);
@@ -48401,7 +48401,7 @@ module.exports = createCharacterList;
 
 
 
-var UnicodeUtils = __webpack_require__(19);
+var UnicodeUtils = __webpack_require__(20);
 
 var substr = UnicodeUtils.substr;
 
@@ -48450,7 +48450,7 @@ module.exports = decodeEntityRanges;
 var _require = __webpack_require__(3),
     OrderedSet = _require.OrderedSet;
 
-var UnicodeUtils = __webpack_require__(19);
+var UnicodeUtils = __webpack_require__(20);
 
 var substr = UnicodeUtils.substr;
 
@@ -49472,7 +49472,7 @@ Object.defineProperty(exports, 'getEntityRanges', {
   }
 });
 
-var _getSelectedBlocks = __webpack_require__(53);
+var _getSelectedBlocks = __webpack_require__(54);
 
 Object.defineProperty(exports, 'getSelectedBlocks', {
   enumerable: true,
@@ -49610,7 +49610,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _getSelectedBlocks = __webpack_require__(53);
+var _getSelectedBlocks = __webpack_require__(54);
 
 var _getSelectedBlocks2 = _interopRequireDefault(_getSelectedBlocks);
 
@@ -49671,7 +49671,7 @@ Object.defineProperty(exports, "__esModule", {
 
 var _draftJs = __webpack_require__(74);
 
-var _getSelectedBlocks = __webpack_require__(53);
+var _getSelectedBlocks = __webpack_require__(54);
 
 var _getSelectedBlocks2 = _interopRequireDefault(_getSelectedBlocks);
 
@@ -49918,7 +49918,7 @@ var _react = __webpack_require__(4);
 
 var _react2 = _interopRequireDefault(_react);
 
-var _input = __webpack_require__(37);
+var _input = __webpack_require__(38);
 
 var _input2 = _interopRequireDefault(_input);
 
@@ -50011,7 +50011,7 @@ var _react = __webpack_require__(4);
 
 var _react2 = _interopRequireDefault(_react);
 
-var _input = __webpack_require__(37);
+var _input = __webpack_require__(38);
 
 var _input2 = _interopRequireDefault(_input);
 
@@ -50210,15 +50210,15 @@ var _reactSelectPlus2 = _interopRequireDefault(_reactSelectPlus);
 
 __webpack_require__(284);
 
-var _validator = __webpack_require__(20);
+var _validator = __webpack_require__(21);
 
 var _validator2 = _interopRequireDefault(_validator);
 
-var _tooltipLink = __webpack_require__(22);
+var _tooltipLink = __webpack_require__(23);
 
 var _tooltipLink2 = _interopRequireDefault(_tooltipLink);
 
-var _utils = __webpack_require__(73);
+var _utils = __webpack_require__(17);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -50238,6 +50238,7 @@ var SelectTab = function (_PureComponent) {
 
     _this.onChange = _this.onChange.bind(_this);
     _this.getOptions = _this.getOptions.bind(_this);
+
     var currentValue = typeof _this.props.value == 'string' ? _this.props.value : _this.formattedValue(_this.props.value);
     _this.props.updateField(_extends({}, _this.props, {
       errors: _this.validationErrors(currentValue),
@@ -50248,6 +50249,27 @@ var SelectTab = function (_PureComponent) {
   }
 
   _createClass(SelectTab, [{
+    key: 'componentDidUpdate',
+    value: function componentDidUpdate(prevProps, prevState) {
+      // TODO: ADD FOR OTHERS ?
+      if (this.reValidate(prevProps)) {
+        this.props.updateField({
+          id: this.props.id,
+          value: this.props.value,
+          errors: this.validationErrors(this.formattedValue(this.props.value))
+        });
+      }
+    }
+  }, {
+    key: 'reValidate',
+    value: function reValidate(prevProps) {
+      var _props = this.props,
+          errors = _props.errors,
+          showErrors = _props.showErrors;
+
+      return prevProps.showErrors != showErrors && showErrors && errors.length == 0;
+    }
+  }, {
     key: 'keyValueObject',
     value: function keyValueObject(object) {
       return function (_ref) {
@@ -50299,12 +50321,12 @@ var SelectTab = function (_PureComponent) {
   }, {
     key: 'validationErrors',
     value: function validationErrors(currentValue) {
-      var errors = void 0;
+      var errors = [];
       if (this.props.customValidator) {
         errors = this.props.customValidator(this.props, value);
       }
+
       if (this.props.mandatory) {
-        errors = [];
         var mandatoryError = this.props.errorMessages.mandatory || _utils.defaultValidationMessages.mandatory;
         if (Array.isArray(currentValue)) {
           if (currentValue.length < 1) {
@@ -50333,18 +50355,18 @@ var SelectTab = function (_PureComponent) {
   }, {
     key: 'render',
     value: function render() {
-      var _props = this.props,
-          label = _props.label,
-          id = _props.id,
-          mandatory = _props.mandatory,
-          options = _props.options,
-          multi = _props.multi,
-          value = _props.value,
-          errors = _props.errors,
-          showErrors = _props.showErrors,
-          tooltip = _props.tooltip,
-          formGroupClassName = _props.formGroupClassName,
-          autoload = _props.autoload;
+      var _props2 = this.props,
+          label = _props2.label,
+          id = _props2.id,
+          mandatory = _props2.mandatory,
+          options = _props2.options,
+          multi = _props2.multi,
+          value = _props2.value,
+          errors = _props2.errors,
+          showErrors = _props2.showErrors,
+          tooltip = _props2.tooltip,
+          formGroupClassName = _props2.formGroupClassName,
+          autoload = _props2.autoload;
 
       var mandatoryMark = mandatory ? _react2.default.createElement(
         'span',
@@ -50356,6 +50378,7 @@ var SelectTab = function (_PureComponent) {
       var SelectPlusComponent = this.customSelectClass;
       var customProps = {};
       if (this.props.async) customProps.loadOptions = this.getOptions;
+
       return _react2.default.createElement(
         'div',
         { className: formGroupClasses.join(' ') },
@@ -50386,9 +50409,9 @@ var SelectTab = function (_PureComponent) {
   }, {
     key: 'customSelectClass',
     get: function get() {
-      var _props2 = this.props,
-          allowNew = _props2.allowNew,
-          async = _props2.async;
+      var _props3 = this.props,
+          allowNew = _props3.allowNew,
+          async = _props3.async;
 
       if (allowNew && async) return _reactSelectPlus.AsyncCreatable;
       if (async) return _reactSelectPlus.Async;
@@ -50430,7 +50453,7 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "defaultFilterOptions", function() { return filterOptions; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_react_input_autosize__ = __webpack_require__(283);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_react_input_autosize___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_react_input_autosize__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_classnames__ = __webpack_require__(71);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_classnames__ = __webpack_require__(72);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_classnames___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_classnames__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2_prop_types__ = __webpack_require__(8);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2_prop_types___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2_prop_types__);
@@ -53732,7 +53755,7 @@ var _react = __webpack_require__(4);
 
 var _react2 = _interopRequireDefault(_react);
 
-var _tooltipLink = __webpack_require__(22);
+var _tooltipLink = __webpack_require__(23);
 
 var _tooltipLink2 = _interopRequireDefault(_tooltipLink);
 
@@ -53882,15 +53905,15 @@ var _propTypes = __webpack_require__(8);
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _validator = __webpack_require__(20);
+var _validator = __webpack_require__(21);
 
 var _validator2 = _interopRequireDefault(_validator);
 
-var _tooltipLink = __webpack_require__(22);
+var _tooltipLink = __webpack_require__(23);
 
 var _tooltipLink2 = _interopRequireDefault(_tooltipLink);
 
-var _utils = __webpack_require__(73);
+var _utils = __webpack_require__(17);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-react-form",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Custom React Form",
   "main": "build/index.js",
   "peerDependencies": {

--- a/src/components/select-tab.js
+++ b/src/components/select-tab.js
@@ -9,8 +9,9 @@ import { defaultValidationMessages } from './../utils';
 class SelectTab extends PureComponent {
   constructor(props) {
     super(props);
-    this.onChange = this.onChange.bind(this);
+    this.onChange   = this.onChange.bind(this);
     this.getOptions = this.getOptions.bind(this);
+
     const currentValue = (typeof this.props.value == 'string') ? this.props.value : this.formattedValue(this.props.value);
     this.props.updateField({
       ...this.props,
@@ -18,6 +19,24 @@ class SelectTab extends PureComponent {
       showErrors: false,
       fromInit: true
     });
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    // TODO: ADD FOR OTHERS ?
+    if (this.reValidate(prevProps)) {
+      this.props.updateField({
+        id: this.props.id,
+        value: this.props.value,
+        errors: this.validationErrors(this.formattedValue(this.props.value))
+      });
+    }
+  }
+
+  reValidate(prevProps) {
+    const { errors, showErrors } = this.props;
+    return (
+      (prevProps.showErrors != showErrors) && showErrors && errors.length == 0
+    )
   }
 
   keyValueObject(object) {
@@ -55,12 +74,12 @@ class SelectTab extends PureComponent {
   }
 
   validationErrors(currentValue) {
-    let errors;
+    let errors = [];
     if (this.props.customValidator) {
       errors = this.props.customValidator(this.props, value);
     }
+
     if (this.props.mandatory) {
-      errors = [];
       const mandatoryError = this.props.errorMessages.mandatory || defaultValidationMessages.mandatory;
       if (Array.isArray(currentValue)) {
         if (currentValue.length < 1) { errors.push(mandatoryError); }
@@ -99,6 +118,7 @@ class SelectTab extends PureComponent {
     let SelectPlusComponent = this.customSelectClass;
     let customProps = {};
     if (this.props.async) customProps.loadOptions = this.getOptions;
+
     return (
       <div className={formGroupClasses.join(' ')}>
         <label htmlFor={id}>

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,7 @@ class CustomReactForm extends Component {
   classForType(type) {
     return FIELD_CLASS[type] || Input;
   }
+
   componentWillReceiveProps(nextProps) {
     this.setState({ fields: this.updatedFields(nextProps.fields) });
   }


### PR DESCRIPTION
* made use of `showErrors` to retrigger the validation. Useful when we need to revalidate a field when another field changes.
* used `componendDidUpdate` because [`componentWillUpdate` will be deprecated](https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate)